### PR TITLE
The issues with the importing from and exporting to network editor format are fixed

### DIFF
--- a/src/networkinfotranslator/exports/export_network_editor.py
+++ b/src/networkinfotranslator/exports/export_network_editor.py
@@ -76,7 +76,8 @@ class NetworkInfoExportToNetworkEditor(NetworkInfoExportToJsonBase):
             connectable_target_node_title = "Species"
             connectable_target_node_categories = ["Species"]
 
-        return {'name': species_reference['referenceId'] + "_style", 'category': "SpeciesReference",
+        return {'name': species_reference['referenceId'] + "_style" if species_reference['referenceId'] else species_reference['id'] + "_style",
+                'category': "SpeciesReference",
                 'sub-category': species_reference['role'],
                 'connectable-source-node-title': connectable_source_node_title,
                 'connectable-source-node-categories': connectable_source_node_categories,
@@ -292,24 +293,24 @@ class NetworkInfoExportToNetworkEditor(NetworkInfoExportToJsonBase):
     def get_ellipse_features(gs, dimensions, offset_x, offset_y):
         ellipse_shape = {'shape': "ellipse"}
         if 'cx' in list(gs.keys()):
-            ellipse_shape['cx'] = gs['cx']['abs'] + 0.01 * gs['cx'][
+            ellipse_shape['center-x'] = gs['cx']['abs'] + 0.01 * gs['cx'][
                 'rel'] * dimensions['width'] + offset_x
         if 'cy' in list(gs.keys()):
-            ellipse_shape['cy'] = gs['cy']['abs'] + 0.01 * gs['cy'][
+            ellipse_shape['center-y'] = gs['cy']['abs'] + 0.01 * gs['cy'][
                 'rel'] * dimensions['height'] + offset_y
         if 'rx' in list(gs.keys()):
-            ellipse_shape['rx'] = gs['rx']['abs'] + 0.01 * gs['rx'][
+            ellipse_shape['radius-x'] = gs['rx']['abs'] + 0.01 * gs['rx'][
                 'rel'] * dimensions['width']
         if 'ry' in list(gs.keys()):
-            ellipse_shape['ry'] = gs['ry']['abs'] + \
+            ellipse_shape['radius-y'] = gs['ry']['abs'] + \
                                   0.01 * gs['ry']['rel'] * dimensions['height']
         if 'ratio' in list(gs.keys()) and gs['ratio'] > 0.0:
             if (dimensions['width'] / dimensions['height']) <= gs['ratio']:
-                ellipse_shape['rx'] = 0.5 * dimensions['width']
-                ellipse_shape['ry'] = (0.5 * dimensions['width'] / gs['ratio'])
+                ellipse_shape['radius-x'] = 0.5 * dimensions['width']
+                ellipse_shape['radius-y'] = (0.5 * dimensions['width'] / gs['ratio'])
             else:
-                ellipse_shape['ry'] = 0.5 * dimensions['height']
-                ellipse_shape['rx'] = gs['ratio'] * 0.5 * dimensions['height']
+                ellipse_shape['radius-y'] = 0.5 * dimensions['height']
+                ellipse_shape['radius-x'] = gs['ratio'] * 0.5 * dimensions['height']
         return ellipse_shape
 
     @staticmethod
@@ -337,10 +338,10 @@ class NetworkInfoExportToNetworkEditor(NetworkInfoExportToJsonBase):
                 rectangle_shape['width'] = gs['ratio'] * dimensions['height']
                 rectangle_shape['x'] += 0.5 * (dimensions['width'] - rectangle_shape['width'])
         if 'rx' in list(gs.keys()):
-            rectangle_shape['rx'] = gs['rx']['abs'] + \
+            rectangle_shape['border-radius-x'] = gs['rx']['abs'] + \
                                     0.01 * gs['rx']['rel'] * 0.5 * dimensions['width']
         if 'ry' in list(gs.keys()):
-            rectangle_shape['ry'] = gs['ry']['abs'] + \
+            rectangle_shape['border-radius-y'] = gs['ry']['abs'] + \
                                     0.01 * gs['ry']['rel'] * 0.5 * dimensions['height']
             return rectangle_shape
 

--- a/src/networkinfotranslator/imports/import_network_editor.py
+++ b/src/networkinfotranslator/imports/import_network_editor.py
@@ -11,8 +11,7 @@ class NetworkInfoImportFromNetworkEditor(NetworkInfoImportBase):
     def extract_info(self, graph):
         super().extract_info(graph)
 
-        f =  open(graph)
-        self.graph_info = json.load(f)
+        self.graph_info = graph
         self.extract_extents(self.graph_info)
         self.extract_background_color(self.graph_info)
         self.extract_entities(self.graph_info)
@@ -422,13 +421,13 @@ class NetworkInfoImportFromNetworkEditor(NetworkInfoImportBase):
         if 'height' in list(rect_shape.keys()):
             rect_shape_info['height'] = {'abs': rect_shape['height'], 'rel': 0}
 
-        # get corner curvature radius rx
-        if 'rx' in list(rect_shape.keys()):
-            rect_shape_info['rx'] = {'abs': rect_shape['rx'], 'rel': 0}
+        # get corner curvature radius x
+        if 'border-radius-x' in list(rect_shape.keys()):
+            rect_shape_info['rx'] = {'abs': rect_shape['border-radius-x'], 'rel': 0}
 
-        # get corner curvature radius ry
-        if 'ry' in list(rect_shape.keys()):
-            rect_shape_info['ry'] = {'abs': rect_shape['ry'], 'rel': 0}
+        # get corner curvature radius y
+        if 'border-radius-y' in list(rect_shape.keys()):
+            rect_shape_info['ry'] = {'abs': rect_shape['border-radius-y'], 'rel': 0}
 
         return rect_shape_info
 
@@ -441,20 +440,20 @@ class NetworkInfoImportFromNetworkEditor(NetworkInfoImportBase):
             self.add_color(ellipse_shape['fill-color'])
 
         # get position cx
-        if 'cx' in list(ellipse_shape.keys()):
-            ellipse_shape_info['cx'] = {'abs': ellipse_shape['cx'] + offset_x, 'rel': 0}
+        if 'center-x' in list(ellipse_shape.keys()):
+            ellipse_shape_info['cx'] = {'abs': ellipse_shape['center-x'] + offset_x, 'rel': 0}
 
         # get position cy
-        if 'cy' in list(ellipse_shape.keys()):
-            ellipse_shape_info['cy'] = {'abs': ellipse_shape['cy'] + offset_y, 'rel': 0}
+        if 'center-y' in list(ellipse_shape.keys()):
+            ellipse_shape_info['cy'] = {'abs': ellipse_shape['center-y'] + offset_y, 'rel': 0}
 
         # get dimension rx
-        if 'rx' in list(ellipse_shape.keys()):
-            ellipse_shape_info['rx'] = {'abs': ellipse_shape['rx'], 'rel': 0}
+        if 'radius-x' in list(ellipse_shape.keys()):
+            ellipse_shape_info['rx'] = {'abs': ellipse_shape['radius-x'], 'rel': 0}
 
         # get dimension ry
-        if 'ry' in list(ellipse_shape.keys()):
-            ellipse_shape_info['ry'] = {'abs': ellipse_shape['ry'], 'rel': 0}
+        if 'radius-y' in list(ellipse_shape.keys()):
+            ellipse_shape_info['ry'] = {'abs': ellipse_shape['radius-y'], 'rel': 0}
 
         return ellipse_shape_info
 


### PR DESCRIPTION
- the graph parameter in the extract_info from now on is a dictionary, so there is no need to treat it like a json object
    
- in export to network editor format, while setting species_reference style, it is checked if the 'referenceId' is set or not. If not, the 'id' of species_reference is used to initialize the style name
    
- 'cx' is replaced with 'center-x' in ellipse shape
    
- 'cy' is replaced with 'center-y' in ellipse shape
    
- 'rx' is replaced with 'radius-x' in ellipse shape
    
- 'ry' is replaced with 'radius-y' in ellipse shape

- 'rx' is replaced with 'border-radius-x' in rectangle shape
    
- 'ry' is replaced with 'border-radius-y' in rectangle shape
